### PR TITLE
Fixed a few python test samples

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,0 +1,71 @@
+package:
+  name: az-2.62.0-r0
+  version: 2.62.0
+  epoch: 0
+  description: Azure CLI
+  copyright:
+    - license: MIT
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3.11-pip
+      - python-3.11
+      - python-3.11-dev
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/paulgibert/azure-cli
+      expected-commit: 297101dfa88827df48b2717dfec3757431dc1fb9
+  - runs: |
+      exit 1
+  - name: Python Build
+    runs: 'pip install wheel
+
+      cd src/azure-cli
+
+      python setup.py bdist_wheel
+
+      cd ../azure-cli-core
+
+      python setup.py bdist_wheel
+
+    '
+  - runs: '# Setup the virtualenv
+
+      python -m venv .venv
+
+      # Bump pip to patch a CVE
+
+      #.venv/bin/pip install --upgrade pip==23.3.2
+
+    '
+  - runs: '.venv/bin/pip install --no-compile src/azure-cli/dist/*.whl src/azure-cli-core/dist/*.whl
+
+    '
+  - runs: 'mkdir -p ${{targets.destdir}}/usr/share/az
+      # Remove pip
+      exit 1
+      rm -rf .venv/lib/python3.11/site-packages/pip
+      rm -rf .venv/lib/python3.11/site-packages/pip-*
+
+      mv .venv ${{targets.destdir}}/usr/share/az/
+      
+      # edit the venv paths
+
+      sed -i "s|/home/build|/usr/share/az|g" ${{targets.destdir}}/usr/share/az/.venv/bin/*
+
+    '
+  - runs: 'mkdir -p ${{targets.destdir}}/usr/bin
+
+      ln -s /usr/share/az/.venv/bin/az ${{targets.destdir}}/usr/bin/az
+
+    '
+  - uses: strip
+test:
+  pipeline:
+    - runs: 'az --version
+
+      '

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -27,7 +27,6 @@ pipeline:
       repository: https://github.com/GitGuardian/ggshield
       tag: v${{package.version}}
       expected-commit: 26ecb71a04496b412e765a39f2209a89ca30f141
-
   - runs: |
       pip3 install certifi -U  # https://github.com/advisories/GHSA-xqr8-7jwr-rhp7
       python3 setup.py bdist_wheel

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -1,0 +1,121 @@
+# Generated from https://pypi.org/project/cassandra-medusa/
+package:
+  name: py3-cassandra-medusa
+  version: 0.22.3
+  epoch: 0
+  description: Apache Cassandra backup and restore tool
+  copyright:
+    - license: Apache-2.0
+  options:
+    no-provides: true
+    no-depends: true
+  dependencies:
+    runtime:
+      - poetry
+      - python-3.11-base
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3.11-installer
+      - py3.11-pip
+      - python-3.11
+      - python-3.11-dev
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/thelastpickle/cassandra-medusa
+      tag: v${{package.version}}
+      expected-commit: 6202aca6e4c2859d2ad601571571a774df7bebc8
+
+  - name: Python Build
+    runs: |
+      pip install wheel
+      pip install poetry==1.8.5
+      poetry add "dnspython==2.6.1"
+      poetry add "pyOpenSSL@^24.0.0"
+      poetry run pip freeze | grep -v cassandra-medusa > requirements.txt
+      POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
+      poetry build
+
+  - runs: |
+      # Setup the virtualenv
+      python -m venv .venv --system-site-packages
+      # Bump pip to patch a CVE
+      .venv/bin/pip install --upgrade pip==24.0 setuptools==70.0.0
+
+  - runs: |
+      .venv/bin/pip install -I -r requirements.txt --no-compile
+      .venv/bin/pip install -I --no-compile dist/*.whl
+
+  - runs: |
+      # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
+      .venv/bin/pip install -I python-snappy --no-compile
+
+  - runs: |
+      # Remove pip
+      rm -rf .venv/lib/python3.11/site-packages/pip
+      rm -rf .venv/lib/python3.11/site-pacakges/pip-*
+
+      mkdir -p ${{targets.destdir}}/home/cassandra
+      mv .venv ${{targets.destdir}}/home/cassandra/
+
+      # edit the venv paths
+      sed -i "s|/home/build|${{targets.destdir}}/home/cassandra|g" ${{targets.destdir}}/home/cassandra/.venv/bin/*
+
+      # allow site-packages
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/home/cassandra/.venv/pyvenv.cfg
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      cp k8s/medusa.sh ${{targets.destdir}}/usr/bin/medusa
+      chmod +x ${{targets.destdir}}/usr/bin/medusa
+
+  - runs: |
+      cp pyproject.toml ${{targets.destdir}}/home/cassandra
+      cp k8s/docker-entrypoint.sh ${{targets.destdir}}/home/cassandra
+      chmod +x ${{targets.destdir}}/home/cassandra/docker-entrypoint.sh
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries and docker entrypoints in the location expected by upstream helm charts"
+    dependencies:
+      runtime:
+        # The entrypoint script fails to start without bash and sleep (which comes from busybox)
+        - bash
+        - busybox
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/home/cassandra/"
+          ln -sf /usr/bin/medusa ${{targets.subpkgdir}}/home/cassandra/medusa
+          # Symlink the binary from usr/bin to /bin
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/bin/grpc_health_probe
+
+update:
+  enabled: true
+  github:
+    identifier: thelastpickle/cassandra-medusa
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - python-3.11
+        - python-3.11-dev
+        - grpc-health-probe
+  pipeline:
+    - runs: medusa --version
+    - runs: |
+        set +e
+        fail() { echo "$@" 1>&2; exit 1; }
+        out=$(/home/cassandra/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
+        status=$?
+        echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message. Exit status $status: $out"
+        echo "medusa.service.grpc.server exited with expected error message"

--- a/reflex0.6.yaml
+++ b/reflex0.6.yaml
@@ -4,249 +4,251 @@ package:
   epoch: 0
   description: Web apps in pure Python
   copyright:
-    - license: Apache-2.0
+  - license: Apache-2.0
   dependencies:
     runtime:
-      - bash
-      - curl
-      - python-3
-      - wget
+    - bash
+    - curl
+    - python-3
+    - wget
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - openssf-compiler-options
-      - poetry
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - python3-dev
-      - wolfi-base
-      - wolfi-baselayout
+    - build-base
+    - busybox
+    - ca-certificates-bundle
+    - openssf-compiler-options
+    - poetry
+    - py3-pip
+    - py3-setuptools
+    - python3
+    - python3-dev
+    - wolfi-base
+    - wolfi-baselayout
 pipeline:
-  - uses: git-checkout
-    with:
-      repository: https://github.com/reflex-dev/reflex
-      tag: v${{package.version}}
-      expected-commit: 0c8192222fe8a6258e768fef82336dce3566671f
-  - runs: '#Fix CVEs
+- uses: git-checkout
+  with:
+    repository: https://github.com/reflex-dev/reflex
+    tag: v${{package.version}}
+    expected-commit: 0c8192222fe8a6258e768fef82336dce3566671f
+- runs: '#Fix CVEs
 
-      poetry add "idna==3.7"
-
-
-      poetry run pip freeze | grep -v reflex > requirements.txt
-
-      poetry build
+    poetry add "idna==3.7"
 
 
-      pip install --root ${{targets.destdir}} -I -r requirements.txt --no-compile
+    poetry run pip freeze | grep -v reflex > requirements.txt
 
-      pip install --root ${{targets.destdir}} dist/reflex-*.whl
+    poetry build
 
-      find ${{targets.destdir}}/usr/lib/python*/site-packages/ \( -type d -a -name test -o -name tests \) -o \( -type f -a -name ''*.pyc'' -o -name ''*.pyo'' \) -exec rm -rf ''{}'' \+
+
+    pip install --root ${{targets.destdir}} -I -r requirements.txt --no-compile
+
+    pip install --root ${{targets.destdir}} dist/reflex-*.whl
+
+    find ${{targets.destdir}}/usr/lib/python*/site-packages/ \( -type d -a -name test
+    -o -name tests \) -o \( -type f -a -name ''*.pyc'' -o -name ''*.pyo'' \) -exec
+    rm -rf ''{}'' \+
 
     '
 update:
   ignore-regex-patterns:
-    - post1
+  - post1
   enabled: true
   github:
     identifier: reflex-dev/reflex
     strip-prefix: v
 test:
   pipeline:
-    - runs: 'reflex --version
+  - runs: 'reflex --version
 
-        alembic --version
+      alembic --version
 
-        alembic --help
+      alembic --help
 
-        coverage --version
+      coverage --version
 
-        coverage --help
+      coverage --help
 
-        coverage-3.12 --version
+      coverage-3.12 --version
 
-        coverage-3.12 --help
+      coverage-3.12 --help
 
-        coverage3 --version
+      coverage3 --version
 
-        coverage3 --help
+      coverage3 --help
 
-        cpuinfo --version
+      cpuinfo --version
 
-        cpuinfo --help
+      cpuinfo --help
 
-        darglint --version
+      darglint --version
 
-        darglint --help
+      darglint --help
 
-        distro --help
+      distro --help
 
-        docutils --version
+      docutils --version
 
-        docutils --help
+      docutils --help
 
-        f2py --version
+      f2py --version
 
-        f2py --help
+      f2py --help
 
-        gunicorn --version
+      gunicorn --version
 
-        gunicorn --help
+      gunicorn --help
 
-        httpx --help
+      httpx --help
 
-        identify-cli --help
+      identify-cli --help
 
-        keyring --help
+      keyring --help
 
-        mako-render --help
+      mako-render --help
 
-        markdown-it --version
+      markdown-it --version
 
-        markdown-it --help
+      markdown-it --help
 
-        nodeenv --version
+      nodeenv --version
 
-        nodeenv --help
+      nodeenv --help
 
-        normalizer --version
+      normalizer --version
 
-        normalizer --help
+      normalizer --help
 
-        numpy-config --version
+      numpy-config --version
 
-        numpy-config --help
+      numpy-config --help
 
-        pip --version
+      pip --version
 
-        pip --help
+      pip --help
 
-        pip3 --version
+      pip3 --version
 
-        pip3 --help
+      pip3 --help
 
-        pip3.12 --version
+      pip3.12 --version
 
-        pip3.12 --help
+      pip3.12 --help
 
-        pipdeptree --version
+      pipdeptree --version
 
-        pipdeptree --help
+      pipdeptree --help
 
-        pkginfo version
+      pkginfo version
 
-        pkginfo --help
+      pkginfo --help
 
-        playwright --version
+      playwright --version
 
-        playwright --help
+      playwright --help
 
-        pre-commit --version
+      pre-commit --version
 
-        pre-commit --help
+      pre-commit --help
 
-        py.test --version
+      py.test --version
 
-        py.test --help
+      py.test --help
 
-        py.test-benchmark --help
+      py.test-benchmark --help
 
-        pygmentize -v
+      pygmentize -v
 
-        pygmentize --help
+      pygmentize --help
 
-        pyproject-build --version
+      pyproject-build --version
 
-        pyproject-build --help
+      pyproject-build --help
 
-        pyright help
+      pyright help
 
-        pyright-python --version
+      pyright-python --version
 
-        pyright-python --help
+      pyright-python --help
 
-        pytest --version
+      pytest --version
 
-        pytest --help
+      pytest --help
 
-        pytest-benchmark --help
+      pytest-benchmark --help
 
-        reflex --help
+      reflex --help
 
-        rst2html --version
+      rst2html --version
 
-        rst2html --help
+      rst2html --help
 
-        rst2html4 --version
+      rst2html4 --version
 
-        rst2html4 --help
+      rst2html4 --help
 
-        rst2html5 --version
+      rst2html5 --version
 
-        rst2html5 --help
+      rst2html5 --help
 
-        rst2latex --version
+      rst2latex --version
 
-        rst2latex --help
+      rst2latex --help
 
-        rst2man --version
+      rst2man --version
 
-        rst2man --help
+      rst2man --help
 
-        rst2odt --version
+      rst2odt --version
 
-        rst2odt --help
+      rst2odt --help
 
-        rst2pseudoxml --version
+      rst2pseudoxml --version
 
-        rst2pseudoxml --help
+      rst2pseudoxml --help
 
-        rst2s5 --version
+      rst2s5 --version
 
-        rst2s5 --help
+      rst2s5 --help
 
-        rst2xetex --version
+      rst2xetex --version
 
-        rst2xetex --help
+      rst2xetex --help
 
-        rst2xml --version
+      rst2xml --version
 
-        rst2xml --help
+      rst2xml --help
 
-        ruff --version
+      ruff --version
 
-        ruff --help
+      ruff --help
 
-        slugify version
+      slugify version
 
-        slugify --help
+      slugify --help
 
-        tabulate --help
+      tabulate --help
 
-        twine --version
+      twine --version
 
-        twine --help
+      twine --help
 
-        typer --version
+      typer --version
 
-        typer --help
+      typer --help
 
-        uvicorn --version
+      uvicorn --version
 
-        uvicorn --help
+      uvicorn --help
 
-        virtualenv --version
+      virtualenv --version
 
-        virtualenv --help
+      virtualenv --help
 
-        wheel version
+      wheel version
 
-        wheel --help
+      wheel --help
 
-        wsdump --help
+      wsdump --help
 
       '


### PR DESCRIPTION
I cleaned up some of the python CVE remediation examples. The following are now in-scope examples:

reflex0.6
CVE-2024-56201: jinja2 -> 3.1.5
CVE-2024-53981: python-multipart -> 0.0.18

reflex0.4
CVE-2024-6345: setuptools -> 70.0.0

ggshield
GHSA-h4gh-qq45-vh27: cryptography -> 43.0.1
CVE-2024-35195: requests -> 2.32.0

airflow (Maybe out of scope)
CVE-2024-34069 werkzeug -> 3.0.3
CVE-2024-49766 werkzeug -> 3.0.6
CVE-2023-46136 werkzeug -> 2.3.8
CVE-2024-49767 werkzeug -> 3.0.6

k8s-sidecar
CVE-2024-35195 requests -> 2.32.0

py3-cassandra-medusa
CVE-2024-52304 aiohttp -> 3.10.11
CVE-2024-42367 aiohttp -> 3.10.2
CVE-2024-39689 certifi -> 2024.07.04
GHSA-h4gh-qq45-vh27 cryptography -> 43.0.1
CVE-2024-35195 requests -> 2.32.0
CVE-2024-6345 setuptools -> 70.0.0
CVE-2024-37891 urllib -> 2.2.2
CVE-2024-53899 virtualenv -> 20.26.6