### PR TITLE
config(cve-pr-closer): adding octosts policy for new cve-pr-closer bot

### DIFF
--- a/.github/chainguard/lifecycle-cve-pr-closer.sts
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts
@@ -4,4 +4,5 @@ issuer: https://accounts.google.com
 subject_pattern: "(106335777097808959681)"
 
 permissions:
+  contents: read
   pull_requests: write

--- a/.github/chainguard/lifecycle-cve-pr-closer.sts
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts
@@ -1,0 +1,7 @@
+issuer: https://accounts.google.com
+
+# lc-cve-pr-closer-cron@staging-enforce-cd1e.iam.gserviceaccount.com
+subject_pattern: "(106335777097808959681)"
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
New bot to close stale CVE remediation PRs.

It only needs access to close PRs and comment on the PR. 