### PR TITLE
airflow/2.10.4: fake cve remediation

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -71,7 +71,7 @@ pipeline:
       # requires EPOCH to be later that 1980
       export SOURCE_DATE_EPOCH=315532800
 
-      # To install mysqlclient wheel
+      # To install mysqlclient wheel.
       export MYSQLCLIENT_CFLAGS=`mysql_config --cflags`
       export MYSQLCLIENT_CFLAGS=`mysql_config --cflags`
 


### PR DESCRIPTION
This is a fake pull request to test if bot `cve-pr-closer` closes the "stale" PR.

CVE-2023-50782 has a pending-upstream-fix advisory here: https://github.com/wolfi-dev/advisories/blob/6c06473c8b6d900d35c41e966b9e7f6e42b21c2f/airflow.advisories.yaml#L193