### PR TITLE
k3s/1.32.3.1: fake cve remediation

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -17,7 +17,7 @@ package:
       - mount
       - runc
       - umount
-      # Do not include runtime dependencies already included in the multicall k3s
+      # Do not include runtime dependencies already included in the multicall k3s.
       # - ctr
       # - crictl
       # - containerd


### PR DESCRIPTION
Testing the cve-pr-closer bot. This PR should not close. The latest event for CVE-2025-46599 is a detection: https://github.com/wolfi-dev/advisories/blob/fbff4167470218d42d63902beac18d29865628eb/k3s.advisories.yaml#L618-L634