### PR TITLE
ggshield/1.28.0: fake cve remediation

### DIFF
--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -2,7 +2,7 @@ package:
   name: ggshield
   version: 1.28.0
   epoch: 100
-  description: Find and fix 360+ types of hardcoded secrets and 70+ types of infrastructure-as-code misconfigurations.
+  description: Find and fix 360+ types of hardcoded secrets and 70+ types of infrastructure-as-code misconfigurations
   copyright:
     - license: MIT
   dependencies:


### PR DESCRIPTION
Testing cve-pr-closer. PR should close for fixed GHSA-34jh-p97f-mpxf: https://github.com/wolfi-dev/advisories/blob/fbff4167470218d42d63902beac18d29865628eb/ggshield.advisories.yaml#L7-L27