### PR TITLE
config(cve-pr-closer/octosts): adding issues write permission

### DIFF
--- a/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-pr-closer.sts.yaml
@@ -6,3 +6,4 @@ subject_pattern: "(106335777097808959681)"
 permissions:
   contents: read
   pull_requests: write
+  issues: write


### PR DESCRIPTION
Adding issues write permissions to attempt to update labels. 