### PR TITLE
Add STS policies for CVE detection service

### DIFF
--- a/.github/chainguard/lifecycle-cve-detection-dev.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-detection-dev.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://accounts.google.com
+
+# Dev service account for testing
+# - cve-detection-sa@jml-test-chainguard-dev.iam.gserviceaccount.com 117144291088285847777
+subject_pattern: "117144291088285847777"
+
+# Allow CVE detection automation to use Melange package information.
+permissions:
+  contents: read

--- a/.github/chainguard/lifecycle-cve-detection.sts.yaml
+++ b/.github/chainguard/lifecycle-cve-detection.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://accounts.google.com
+
+# Staging service account
+# - cve-detection-sa@staging-enforce-cd1e.iam.gserviceaccount.com 101982940773329773733
+subject_pattern: "101982940773329773733"
+
+# Allow CVE detection automation to use Melange package information.
+permissions:
+  contents: read


### PR DESCRIPTION
## What
Add STS policies for CVE detection service access to test-remediation-packages

## Why
The CVE detection service needs to access this repository to analyze patch information. This adds both dev and staging STS policies to enable that access.

## Notes
This allows the cve-detection service accounts to clone the repo with read-only access. The dev policy is for testing in jml-test-chainguard-dev project, while the staging policy is for the staging-enforce environment.