### PR TITLE
Drop checks: write from elastic-build

### DIFF
--- a/.github/chainguard/elastic-build.sts.yaml
+++ b/.github/chainguard/elastic-build.sts.yaml
@@ -7,4 +7,3 @@ subject_pattern: "(105587019147205988443|110897445954037084144)"
 
 permissions:
   contents: read
-  checks: write


### PR DESCRIPTION
Slack thread: https://chainguard-dev.slack.com/archives/C063AT3FVFA/p1777648125322809

Given that elastic-build seems to use a dedicated GitHub Application Install for check run creation and updates (https://github.com/chainguard-dev/mono/blob/main/build/cmd/job/main.go#L384), we don't seem to need to have `checks: write` for what Octo-STS is doing in elastic-build.  I'd like an elastic-build expert to confirm whether or not this is true.

Removing this would mean a much more even spread of elastic-build traffic across the Octo-STS installations.